### PR TITLE
chore: renamed the old AccountsController controller

### DIFF
--- a/lib/simplified_banking_api_web/controllers/events_controller.ex
+++ b/lib/simplified_banking_api_web/controllers/events_controller.ex
@@ -1,8 +1,8 @@
-defmodule SimplifiedBankingApiWeb.AccountsController do
+defmodule SimplifiedBankingApiWeb.EventsController do
   @moduledoc """
-  Accounts controller.
+  Events controller.
 
-  This module is responsible to handle all incoming requests related to accounts.
+  This module is responsible to handle all incoming events.
   """
   use SimplifiedBankingApiWeb, :controller
 
@@ -26,7 +26,8 @@ defmodule SimplifiedBankingApiWeb.AccountsController do
         |> put_status(201)
         |> render("show.json", %{account: account})
 
-        # TODO: escrever o cenário de erro
+      error ->
+        error
     end
   end
 end

--- a/lib/simplified_banking_api_web/router.ex
+++ b/lib/simplified_banking_api_web/router.ex
@@ -17,7 +17,7 @@ defmodule SimplifiedBankingApiWeb.Router do
   scope "/", SimplifiedBankingApiWeb do
     pipe_through :api
 
-    post "/event", AccountsController, :handle_event
+    post "/event", EventsController, :handle_event
 
     post "/reset", ResetController, :reset
   end

--- a/test/simplified_banking_api_web/controllers/events_controller_test.exs
+++ b/test/simplified_banking_api_web/controllers/events_controller_test.exs
@@ -1,4 +1,4 @@
-defmodule SimplifiedBankingApiWeb.AccountsControllerTest do
+defmodule SimplifiedBankingApiWeb.EventsControllerTest do
   use SimplifiedBankingApiWeb.ConnCase, async: false
 
   import SimplifiedBankingApi.Factory


### PR DESCRIPTION
Por questões de nomenclatura, este PR renomeia o módulo `AccountsController` para `EventsController`