### PR TITLE
fix: id should be string

### DIFF
--- a/lib/simplified_banking_api/accounts.ex
+++ b/lib/simplified_banking_api/accounts.ex
@@ -18,12 +18,12 @@ defmodule SimplifiedBankingApi.Accounts do
       %{:ok, %SimplifiedBankingApi.Accounts.Schemas.Account{
         __meta__: #Ecto.Schema.Metadata<:loaded, "accounts">,
         balance: 100,
-        id: 1234,
+        id: "1234",
         inserted_at: ~N[2022-04-05 03:26:44],
         updated_at: ~N[2022-04-05 03:26:44]
       }}
   """
-  @spec deposit(account_id :: integer(), amount :: integer()) ::
+  @spec deposit(account_id :: String.t(), amount :: integer()) ::
           {:ok, Account.t()} | {:error, atom()}
   def deposit(account_id, amount) do
     Repo.transaction(fn ->
@@ -74,12 +74,12 @@ defmodule SimplifiedBankingApi.Accounts do
       %{:ok, %SimplifiedBankingApi.Accounts.Schemas.Account{
         __meta__: #Ecto.Schema.Metadata<:loaded, "accounts">,
         balance: 90,
-        id: 1234,
+        id: "1234",
         inserted_at: ~N[2022-04-05 03:26:44],
         updated_at: ~N[2022-06-13 12:33:48]
       }}
   """
-  @spec withdraw(account_id :: integer(), amount :: integer()) ::
+  @spec withdraw(account_id :: String.t(), amount :: integer()) ::
           {:ok, Account.t()} | {:error, atom()}
   def withdraw(account_id, amount) do
     Repo.transaction(fn ->
@@ -115,7 +115,7 @@ defmodule SimplifiedBankingApi.Accounts do
         %SimplifiedBankingApi.Accounts.Schemas.Account{
         __meta__: #Ecto.Schema.Metadata<:loaded, "accounts">,
         balance: 90,
-        id: 1234,
+        id: "1234",
         inserted_at: ~N[2022-04-05 03:26:44],
         updated_at: ~N[2022-06-13 12:33:48]
       },
@@ -124,16 +124,16 @@ defmodule SimplifiedBankingApi.Accounts do
         %SimplifiedBankingApi.Accounts.Schemas.Account{
         __meta__: #Ecto.Schema.Metadata<:loaded, "accounts">,
         balance: 110,
-        id: 5678,
+        id: "5678",
         inserted_at: ~N[2022-04-05 03:26:44],
         updated_at: ~N[2022-06-13 12:33:48]
       }
     }
   """
   @spec transfer(
-          origin_account :: integer(),
+          origin_account :: String.t(),
           amount :: integer(),
-          destination_account :: integer()
+          destination_account :: String.t()
         ) ::
           {:ok, origin :: Account.t(), destination :: Account.t()} | {:error, atom()}
   def transfer(origin_account, amount, destination_account) do
@@ -194,7 +194,7 @@ defmodule SimplifiedBankingApi.Accounts do
       iex (1)> Accounts.get_balance(9999)
       {:error, :not_found}
   """
-  @spec get_balance(account_id :: integer()) :: {:ok, integer()} | {:error, :not_found}
+  @spec get_balance(account_id :: String.t()) :: {:ok, integer()} | {:error, :not_found}
   def get_balance(account_id) do
     Repo.transaction(fn ->
       case Repo.one(Account, id: account_id) do

--- a/lib/simplified_banking_api/accounts/schemas/account.ex
+++ b/lib/simplified_banking_api/accounts/schemas/account.ex
@@ -11,7 +11,7 @@ defmodule SimplifiedBankingApi.Accounts.Schemas.Account do
     :balance
   ]
 
-  @primary_key {:id, :integer, autogenerate: false}
+  @primary_key {:id, :string, autogenerate: false}
   schema "accounts" do
     field :balance, :integer, default: 0
 

--- a/priv/repo/migrations/20220407230224_update_id_type_accounts_table.exs
+++ b/priv/repo/migrations/20220407230224_update_id_type_accounts_table.exs
@@ -1,0 +1,9 @@
+defmodule SimplifiedBankingApi.Repo.Migrations.UpdateIdTypeAccountsTable do
+  use Ecto.Migration
+
+  def change do
+    alter table("accounts") do
+      modify :id, :string
+    end
+  end
+end

--- a/test/simplified_banking_api/accounts_test.exs
+++ b/test/simplified_banking_api/accounts_test.exs
@@ -10,11 +10,11 @@ defmodule SimplifiedBankingApi.AccountsTest do
     test "creates an account and deposit the amount when the account doesnt exists" do
       assert [] == Repo.all(Account, [])
 
-      assert {:ok, _account} = Accounts.deposit(1234, 100)
+      assert {:ok, _account} = Accounts.deposit("1234", 100)
 
       [account] = Repo.all(Account, [])
 
-      assert 1234 == account.id
+      assert "1234" == account.id
       assert 100 == account.balance
     end
 
@@ -37,7 +37,7 @@ defmodule SimplifiedBankingApi.AccountsTest do
     end
 
     test "fails if the account doesn't exist" do
-      assert {:error, :not_found} = Accounts.withdraw(123, 1000)
+      assert {:error, :not_found} = Accounts.withdraw("123", 1000)
     end
   end
 
@@ -58,11 +58,11 @@ defmodule SimplifiedBankingApi.AccountsTest do
     end
 
     test "fails if the origin account doesn't exist", ctx do
-      assert {:error, :not_found} = Accounts.transfer(123, 1000, ctx.destination_account)
+      assert {:error, :not_found} = Accounts.transfer("123", 1000, ctx.destination_account)
     end
 
     test "fails if the destination account doesn't exist", ctx do
-      assert {:error, :not_found} = Accounts.transfer(ctx.origin_account, 1000, 567)
+      assert {:error, :not_found} = Accounts.transfer(ctx.origin_account, 1000, "567")
     end
   end
 
@@ -80,7 +80,7 @@ defmodule SimplifiedBankingApi.AccountsTest do
 
   describe "reset_accounts_table/0" do
     test "resets all the database data" do
-      insert(:account, id: 1)
+      insert(:account, id: "1")
 
       insert_list(8, :account)
 
@@ -92,7 +92,7 @@ defmodule SimplifiedBankingApi.AccountsTest do
       assert [] == Repo.all(Account, [])
 
       # can create a new account with the same id that was previously used
-      insert(:account, id: 1)
+      insert(:account, id: "1")
     end
   end
 end

--- a/test/simplified_banking_api_web/controllers/balance_controller_test.exs
+++ b/test/simplified_banking_api_web/controllers/balance_controller_test.exs
@@ -9,17 +9,17 @@ defmodule SimplifiedBankingApiWeb.BalanceControllerTest do
 
   describe "GET /balance" do
     test "succeds getting account balance", ctx do
-      insert(:account, id: 1, balance: 1000)
+      account_id = insert(:account, balance: 1000).id
 
       assert "1000" ==
                ctx.conn
-               |> get("/balance", %{account_id: 1})
+               |> get("/balance", %{account_id: account_id})
                |> response(200)
     end
 
     test "fails to get the balance if the account doesn't exist'", ctx do
       assert ctx.conn
-             |> get("/balance", %{account_id: 1})
+             |> get("/balance", %{account_id: "1"})
              |> response(404)
     end
   end

--- a/test/simplified_banking_api_web/controllers/events_controller_test.exs
+++ b/test/simplified_banking_api_web/controllers/events_controller_test.exs
@@ -20,12 +20,12 @@ defmodule SimplifiedBankingApiWeb.EventsControllerTest do
 
       assert [] == Repo.all(Account, [])
 
-      assert %{"destination" => %{"balance" => 10, "id" => 1234}} =
+      assert %{"destination" => %{"balance" => 10, "id" => "1234"}} =
                ctx.conn
                |> post("/event", params)
                |> json_response(201)
 
-      account = Repo.one(Account, id: 1234)
+      account = Repo.one(Account, id: "1234")
 
       assert 10 == account.balance
     end
@@ -38,12 +38,12 @@ defmodule SimplifiedBankingApiWeb.EventsControllerTest do
 
       assert [] == Repo.all(Account, [])
 
-      assert %{"destination" => %{"balance" => 0, "id" => 1234}} =
+      assert %{"destination" => %{"balance" => 0, "id" => "1234"}} =
                ctx.conn
                |> post("/event", params)
                |> json_response(201)
 
-      account = Repo.one(Account, id: 1234)
+      account = Repo.one(Account, id: "1234")
 
       assert 0 == account.balance
     end
@@ -91,7 +91,7 @@ defmodule SimplifiedBankingApiWeb.EventsControllerTest do
     test "fails if the account doesn't exist'", ctx do
       params = %{
         type: "withdraw",
-        origin: 123,
+        origin: "123",
         amount: 60
       }
 
@@ -132,7 +132,7 @@ defmodule SimplifiedBankingApiWeb.EventsControllerTest do
     test "fails if the origin account doesn't exist'", ctx do
       params = %{
         type: "transfer",
-        origin: 123,
+        origin: "123",
         amount: 60,
         destination: ctx.destination
       }
@@ -147,7 +147,7 @@ defmodule SimplifiedBankingApiWeb.EventsControllerTest do
         type: "transfer",
         origin: ctx.origin,
         amount: 60,
-        destination: 123
+        destination: "123"
       }
 
       assert ctx.conn

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -10,7 +10,7 @@ defmodule SimplifiedBankingApi.Factory do
   def account_factory do
     %Account{
       balance: 100,
-      id: sequence(:id, & &1),
+      id: sequence(:id, &"#{&1}"),
       inserted_at: ~N[2022-04-05 01:40:11],
       updated_at: ~N[2022-04-05 01:40:11]
     }


### PR DESCRIPTION
O campo `id` da tabela `accounts` era do tipo integer, mas ele deveria ser do tipo string. 
Este PR modifica o tipo da coluna `id`