### PR TITLE
fix: create destination account if doesnt exist, while transfering

### DIFF
--- a/test/simplified_banking_api/accounts_test.exs
+++ b/test/simplified_banking_api/accounts_test.exs
@@ -61,8 +61,18 @@ defmodule SimplifiedBankingApi.AccountsTest do
       assert {:error, :not_found} = Accounts.transfer(123, 1000, ctx.destination_account)
     end
 
-    test "fails if the destination account doesn't exist", ctx do
-      assert {:error, :not_found} = Accounts.transfer(ctx.origin_account, 1000, 567)
+    test "creates a new account if the destination account doesn't exist", ctx do
+      destination_id = "567123"
+
+      query = from a in Account, where: a.id == ^destination_id
+      assert false == Repo.exists?(query)
+
+      assert {:ok, origin, destination} = Accounts.transfer(ctx.origin_account, 99, destination_id)
+
+      assert true == Repo.exists?(query)
+
+      assert 1 == origin.balance
+      assert 99 == destination.balance
     end
   end
 

--- a/test/simplified_banking_api/accounts_test.exs
+++ b/test/simplified_banking_api/accounts_test.exs
@@ -67,12 +67,14 @@ defmodule SimplifiedBankingApi.AccountsTest do
       query = from a in Account, where: a.id == ^destination_id
       assert false == Repo.exists?(query)
 
-      assert {:ok, origin, destination} = Accounts.transfer(ctx.origin_account, 99, destination_id)
+      assert {:ok, origin, destination} =
+               Accounts.transfer(ctx.origin_account, 99, destination_id)
 
       assert true == Repo.exists?(query)
 
       assert 1 == origin.balance
       assert 99 == destination.balance
+    end
   end
 
   describe "get_balance/1" do

--- a/test/simplified_banking_api_web/controllers/events_controller_test.exs
+++ b/test/simplified_banking_api_web/controllers/events_controller_test.exs
@@ -145,6 +145,8 @@ defmodule SimplifiedBankingApiWeb.EventsControllerTest do
     test "create a new account if the destination doesn't exist", %{origin: origin_id} = ctx do
       destination_id = "123"
 
+      assert 2 == Repo.aggregate(Account, :count)
+
       params = %{
         type: "transfer",
         origin: origin_id,
@@ -159,6 +161,8 @@ defmodule SimplifiedBankingApiWeb.EventsControllerTest do
                ctx.conn
                |> post("/event", params)
                |> json_response(201)
+
+      assert 3 == Repo.aggregate(Account, :count)
     end
   end
 end

--- a/test/simplified_banking_api_web/controllers/events_controller_test.exs
+++ b/test/simplified_banking_api_web/controllers/events_controller_test.exs
@@ -142,17 +142,23 @@ defmodule SimplifiedBankingApiWeb.EventsControllerTest do
              |> response(404)
     end
 
-    test "fails if the destination account doesn't exist'", ctx do
+    test "create a new account if the destination doesn't exist", %{origin: origin_id} = ctx do
+      destination_id = "123"
+
       params = %{
         type: "transfer",
-        origin: ctx.origin,
+        origin: origin_id,
         amount: 60,
-        destination: 123
+        destination: destination_id
       }
 
-      assert ctx.conn
-             |> post("/event", params)
-             |> response(404)
+      assert %{
+               "origin" => %{"balance" => 40, "id" => origin_id},
+               "destination" => %{"balance" => 60, "id" => destination_id}
+             } ==
+               ctx.conn
+               |> post("/event", params)
+               |> json_response(201)
     end
   end
 end


### PR DESCRIPTION
O endpoint de transferência retornava 404 quando a conta de destino não existia. Porém, é uma exigência do projeto, que se a conta de destino não exisitir, ela deve ser criada com o valor `amount` da transferência.

Este PR faz esta mudificação