### PR TITLE
fix: repo calls

### DIFF
--- a/test/simplified_banking_api/accounts_test.exs
+++ b/test/simplified_banking_api/accounts_test.exs
@@ -8,13 +8,12 @@ defmodule SimplifiedBankingApi.AccountsTest do
 
   describe "deposit/2" do
     test "creates an account and deposit the amount when the account doesnt exists" do
-      assert [] == Repo.all(Account, [])
+      assert nil == Repo.get(Account, "1234")
 
       assert {:ok, _account} = Accounts.deposit("1234", 100)
 
-      [account] = Repo.all(Account, [])
+      account = Repo.get(Account, "1234")
 
-      assert "1234" == account.id
       assert 100 == account.balance
     end
 
@@ -100,7 +99,7 @@ defmodule SimplifiedBankingApi.AccountsTest do
       Accounts.reset_accounts_table()
 
       # the database is empty
-      assert [] == Repo.all(Account, [])
+      assert 0 == Repo.aggregate(Account, :count)
 
       # can create a new account with the same id that was previously used
       insert(:account, id: "1")

--- a/test/simplified_banking_api_web/controllers/events_controller_test.exs
+++ b/test/simplified_banking_api_web/controllers/events_controller_test.exs
@@ -18,14 +18,14 @@ defmodule SimplifiedBankingApiWeb.EventsControllerTest do
         amount: 10
       }
 
-      assert [] == Repo.all(Account, [])
+      assert nil == Repo.get(Account, "1234")
 
       assert %{"destination" => %{"balance" => 10, "id" => "1234"}} =
                ctx.conn
                |> post("/event", params)
                |> json_response(201)
 
-      account = Repo.one(Account, id: "1234")
+      account = Repo.get(Account, "1234")
 
       assert 10 == account.balance
     end
@@ -36,14 +36,14 @@ defmodule SimplifiedBankingApiWeb.EventsControllerTest do
         destination: "1234"
       }
 
-      assert [] == Repo.all(Account, [])
+      assert nil == Repo.get(Account, "1234")
 
       assert %{"destination" => %{"balance" => 0, "id" => "1234"}} =
                ctx.conn
                |> post("/event", params)
                |> json_response(201)
 
-      account = Repo.one(Account, id: "1234")
+      account = Repo.get(Account, "1234")
 
       assert 0 == account.balance
     end
@@ -62,7 +62,7 @@ defmodule SimplifiedBankingApiWeb.EventsControllerTest do
                |> post("/event", params)
                |> json_response(201)
 
-      account = Repo.one(Account, id: account_id)
+      account = Repo.get(Account, account_id)
 
       assert 101 == account.balance
     end
@@ -83,7 +83,7 @@ defmodule SimplifiedBankingApiWeb.EventsControllerTest do
                |> post("/event", params)
                |> json_response(201)
 
-      account = Repo.one(Account, id: account_id)
+      account = Repo.get(Account, account_id)
 
       assert 40 == account.balance
     end
@@ -145,7 +145,7 @@ defmodule SimplifiedBankingApiWeb.EventsControllerTest do
     test "create a new account if the destination doesn't exist", %{origin: origin_id} = ctx do
       destination_id = "123"
 
-      assert 2 == Repo.aggregate(Account, :count)
+      assert nil == Repo.get(Account, "123")
 
       params = %{
         type: "transfer",
@@ -162,7 +162,7 @@ defmodule SimplifiedBankingApiWeb.EventsControllerTest do
                |> post("/event", params)
                |> json_response(201)
 
-      assert 3 == Repo.aggregate(Account, :count)
+      assert %Account{} = Repo.get(Account, "123")
     end
   end
 end


### PR DESCRIPTION
Algumas chamadas para as funções do móodulo SimplifiedBankingApi.Repo estavam erradas. Este PR corrige as chamadas