### PR TITLE
feat: validate withdraw input

### DIFF
--- a/lib/simplified_banking_api/changeset_validation.ex
+++ b/lib/simplified_banking_api/changeset_validation.ex
@@ -42,12 +42,12 @@ defmodule SimplifiedBankingApi.ChangesetValidation do
     end)
   end
 
-  def validate_amount(changeset, field) do
+  def validate_greater_or_equals_zero(changeset, field) do
     Changeset.validate_change(changeset, field, fn ^field, value ->
       if value >= 0 do
         []
       else
-        [{field, "the amount must be greater or equals to zero"}]
+        [{field, "must be greater or equals to zero"}]
       end
     end)
   end
@@ -57,7 +57,7 @@ defmodule SimplifiedBankingApi.ChangesetValidation do
       if only_numbers?(value) do
         []
       else
-        [{field, "this field must contain only numbers"}]
+        [{field, "must contain only numbers"}]
       end
     end)
   end

--- a/lib/simplified_banking_api/events/inputs/deposit_input.ex
+++ b/lib/simplified_banking_api/events/inputs/deposit_input.ex
@@ -23,6 +23,6 @@ defmodule SimplifiedBankingApi.Events.Inputs.DepositInput do
     |> validate_inclusion(:type, ["deposit"])
     |> trim(:destination)
     |> validate_account_id(:destination)
-    |> validate_amount(:amount)
+    |> validate_greater_or_equals_zero(:amount)
   end
 end

--- a/lib/simplified_banking_api/events/inputs/withdraw_input.ex
+++ b/lib/simplified_banking_api/events/inputs/withdraw_input.ex
@@ -1,0 +1,28 @@
+defmodule SimplifiedBankingApi.Events.Inputs.WithdrawInput do
+  @moduledoc """
+  Input validator to the withdraw event.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+  import SimplifiedBankingApi.ChangesetValidation
+
+  @required [:type, :origin, :amount]
+
+  @derive Jason.Encoder
+  embedded_schema do
+    field :type, :string
+    field :origin, :string
+    field :amount, :integer
+  end
+
+  @doc false
+  def changeset(model \\ %__MODULE__{}, params) do
+    model
+    |> cast(params, @required)
+    |> validate_required(@required)
+    |> validate_inclusion(:type, ["withdraw"])
+    |> trim(:origin)
+    |> validate_account_id(:origin)
+    |> validate_greater_or_equals_zero(:amount)
+  end
+end

--- a/test/simplified_banking_api_web/controllers/events_controller_test.exs
+++ b/test/simplified_banking_api_web/controllers/events_controller_test.exs
@@ -87,7 +87,7 @@ defmodule SimplifiedBankingApiWeb.EventsControllerTest do
         amount: 1200
       }
 
-      assert %{"error" => %{"destination" => "this field must contain only numbers"}} =
+      assert %{"error" => %{"destination" => "must contain only numbers"}} =
                ctx.conn
                |> post("/event", params)
                |> json_response(422)
@@ -112,7 +112,7 @@ defmodule SimplifiedBankingApiWeb.EventsControllerTest do
         amount: -1
       }
 
-      assert %{"error" => %{"amount" => "the amount must be greater or equals to zero"}} =
+      assert %{"error" => %{"amount" => "must be greater or equals to zero"}} =
                ctx.conn
                |> post("/event", params)
                |> json_response(422)
@@ -149,6 +149,57 @@ defmodule SimplifiedBankingApiWeb.EventsControllerTest do
       assert ctx.conn
              |> post("/event", params)
              |> response(404)
+    end
+
+    test "fails when the `amount` is a string", ctx do
+      params = %{
+        type: "withdraw",
+        origin: "134",
+        amount: "i'm not a number"
+      }
+
+      assert %{"error" => %{"amount" => "is invalid"}} =
+               ctx.conn
+               |> post("/event", params)
+               |> json_response(422)
+    end
+
+    test "fails when the `origin` is not a string of numbers", ctx do
+      params = %{
+        type: "withdraw",
+        origin: "I'm not a number",
+        amount: 1200
+      }
+
+      assert %{"error" => %{"origin" => "must contain only numbers"}} =
+               ctx.conn
+               |> post("/event", params)
+               |> json_response(422)
+    end
+
+    test "fails when the `origin` is missing", ctx do
+      params = %{
+        type: "withdraw",
+        amount: 1200
+      }
+
+      assert %{"error" => %{"origin" => "can't be blank"}} =
+               ctx.conn
+               |> post("/event", params)
+               |> json_response(422)
+    end
+
+    test "fails when the `amount` is less than zero", ctx do
+      params = %{
+        type: "withdraw",
+        origin: "123",
+        amount: -1
+      }
+
+      assert %{"error" => %{"amount" => "must be greater or equals to zero"}} =
+               ctx.conn
+               |> post("/event", params)
+               |> json_response(422)
     end
   end
 


### PR DESCRIPTION
Valida o _request body_ de saque antes de processar a requisição